### PR TITLE
Remove jittery scroll bar

### DIFF
--- a/tikibar/templates/tikibar/tikibar.html
+++ b/tikibar/templates/tikibar/tikibar.html
@@ -72,7 +72,6 @@ function addClientsideProfiling(timing) {
     var page_load_time = timing.domComplete - timing.responseStart;
     jQuery('.tiki-page-load-time').text(page_load_time);
     jQuery('.tiki-js-client-render-time').css('display', 'block');
-    transmitSize();
 }
 
 // Client-side performance monitoring
@@ -182,7 +181,6 @@ function transmitSize() {
     }
 }
 jQuery(function($) {
-    window.onresize = jQuery.debounce(100, transmitSize);
     transmitSize();
     jQuery(window).load(transmitSize); // For Mobile Safari
 


### PR DESCRIPTION
Turns out this was due to a new height being transmitted several times on window resize and clientSideProfiling. The resolution to that was to remove transmitSize from window resize and clientSideProfiling. 

Thanks to Philip for help in pinpointing guilty function calls!
