### PR TITLE
Show CPU time for request

### DIFF
--- a/tikibar/templates/tikibar/tikibar.html
+++ b/tikibar/templates/tikibar/tikibar.html
@@ -716,7 +716,9 @@ html {
     <div class="tikibasement" id="tiki-server-time">
         <h2>Server render time</h2>
 
-        <p>Total server render time: <strong>{{ tiki.total_time.duration|floatformat:0 }}</strong><span class="tiki-qualifier">ms</span></p>
+        <p>Total server render time: <strong>{{ tiki.total_time.duration|floatformat:0 }}</strong><span class="tiki-qualifier">ms</span>
+        User CPU: <strong>{{ tiki.user_cpu.duration|floatformat:0 }}</strong><span class="tiki-qualifier">ms</span>
+        System CPU: <strong>{{ tiki.system_cpu.duration|floatformat:0 }}</strong><span class="tiki-qualifier">ms</span></p>
 
         <div class="tiki-traffic">
             <div class="tiki-traffic-wrapper">


### PR DESCRIPTION
This adds the time the process handling the request spends in [user and system mode on the CPU](https://en.wikipedia.org/wiki/CPU_time) to the server render time panel. My intent is to add a measure of the amount of work done by python.

It currently looks like

<img width="715" alt="screen shot 2016-06-24 at 8 18 49 pm" src="https://cloud.githubusercontent.com/assets/10963385/16355650/ff9ff598-3a82-11e6-8fd3-4960db43cbdf.png">
