### PR TITLE
Track growth in memory usage during request

### DIFF
--- a/tikibar/templates/tikibar/tikibar.html
+++ b/tikibar/templates/tikibar/tikibar.html
@@ -771,6 +771,7 @@ html {
         <p>Total server render time: <strong>{{ tiki.total_time.duration|floatformat:0 }}</strong><span class="tiki-qualifier">ms</span></p>
         <p>User CPU: <strong>{{ tiki.user_cpu.duration|floatformat:0 }}</strong><span class="tiki-qualifier">ms</span></p>
         <p>System CPU: <strong>{{ tiki.system_cpu.duration|floatformat:0 }}</strong><span class="tiki-qualifier">ms</span></p>
+        <p>Memory Growth: <strong>{{ tiki.rss_growth|floatformat:0 }}</strong><span class="tiki-qualifier">MB</span></p>
 
         <div class="tiki-traffic">
             <div class="tiki-traffic-wrapper">


### PR DESCRIPTION
I stumbled across an issue where @eyalr mentioned this idea and thought it would be easy to implement. I have verified these numbers are correct via attaching to core-web and tracking uwsgi RSS usage.

![screen shot 2017-04-07 at 10 11 20 am](https://cloud.githubusercontent.com/assets/10963385/24806491/ad63f264-1b7a-11e7-8329-d7d41e67aa51.png)
