### PR TITLE
Fix setup.py, broken after deleting HISTORY.rst.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,9 @@ if sys.argv[-1] == 'tag':
     sys.exit()
 
 readme = open('README.rst').read()
-history = open('HISTORY.rst').read().replace('.. :changelog:', '')
+# Replace the title underline '====' from the ReST of the changelog
+# with simple underline '---'
+history = open('CHANGELOG.txt').read().replace('=========', '---------')
 
 setup(
     name='tikibar',


### PR DESCRIPTION
I didn't notice that setup.py was using HISTORY.rst, which I deleted. I'm updating the script so it uses CHANGELOG.txt now.