### PR TITLE
[MINOR] Updated sqlparse at least to 0.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django>=1.8.0
 wheel==0.24.0
-sqlparse==0.1.18
+sqlparse<=0.3.1
 # Additional requirements go here

--- a/tikibar/version.py
+++ b/tikibar/version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 2, 2)
+__version_info__ = (0, 3, 0)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
Updated sqlparse<=0.3.1 so tikibar can be used with py2.7 and py3.5 (possibly with py3.7 too).