### PR TITLE
Released Eventbrite Common Utilities Library version 0.3.1

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.3.1 (2021-08-12)
+------------------
+- Revert "Removed CircleCI" (#50)
+- fixes for py3 compatibility (#49)
+- Removed CircleCI
+
 0.2.1 (2020-04-24)
 ------------------
 - Fixed a bug in PySOA client patch code.

--- a/tikibar/version.py
+++ b/tikibar/version.py
@@ -1,3 +1,3 @@
 from six.moves import map
-__version_info__ = (0, 3, 0)
-__version__ = '-'.join([_f for _f in ['.'.join(map(str, __version_info__[:3])), (__version_info__[3:] or [None])[0]] if _f])
+__version_info__ = (0, 3, 1)
+__version__ = '-'.join(filter(None, ['.'.join(map(str, __version_info__[:3])), (__version_info__[3:] or [None])[0]]))


### PR DESCRIPTION
Changelog Details:
- Revert "Removed CircleCI" (#50)
- fixes for py3 compatibility (#49)
- Removed CircleCI