### PR TITLE
[PATCH] Fix BoldKeywordFilter process() params

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
+        'sqlparse~=0.3.1'
     ],
     license="BSD",
     zip_safe=False,

--- a/tikibar/sql_utils.py
+++ b/tikibar/sql_utils.py
@@ -8,7 +8,7 @@ import re
 class BoldKeywordFilter:
     """sqlparse filter to bold SQL keywords"""
     @staticmethod
-    def process(stack, stream):
+    def process(stream):
         """Process the token stream"""
         for token_type, value in stream:
             is_keyword = token_type in T.Keyword


### PR DESCRIPTION
For Python 3 compatibility, `sqlparse` was bumped to version 0.3.1 
Custom `sqlparse` filters now receive a single `stream` parameter in `process()` method. 